### PR TITLE
🔗 Fix broken links on rendered page

### DIFF
--- a/mkdocs-project-dir/docs/Clusters/Michael.md
+++ b/mkdocs-project-dir/docs/Clusters/Michael.md
@@ -99,9 +99,9 @@ works. Any variations that Michael has should be listed on this page.
 
 ## Submitting a job
 
-Create a [job script](Example_Submission_Scripts) for
+Create a [job script](../Wiki_Export/Example_Submission_Scripts) for
 non-interactive use and submit it using
-[qsub](Batch_Processing). Jobscripts must begin `#!/bin/bash
+[qsub](../Wiki_Export/Background/Batch_Processing). Jobscripts must begin `#!/bin/bash
 -l` in order to run as a login shell and get your login environment and
 modules.
 


### PR DESCRIPTION
I've noticed, however, that these were not the only ones. mkdocs actually shows a list when it builds the pages (and [there are a few in the last build by Travis](https://travis-ci.org/github/UCL-RITS/mkdocs-rc-docs/builds/702447972#L262)).

I'd suggest the following:
1. to activate CI on pull-requests (they are currently disabled) so you get an output from contributors straight away. (switch under [settings](https://travis-ci.org/github/UCL-RITS/mkdocs-rc-docs/settings))
1. Either use `strict: true` on https://github.com/UCL-RITS/mkdocs-rc-docs/blob/3ccd61de0b853813c4c40d2d1b5b90abdbfa00f0/mkdocs-project-dir/mkdocs.yml#L10 currently commented out or change the `exit` code on https://github.com/UCL-RITS/mkdocs-rc-docs/blob/3ccd61de0b853813c4c40d2d1b5b90abdbfa00f0/builder/deploy.sh#L21 to something different than 0 when the compilation fails.