### PR TITLE
Feature: Respect light vs dark mode user preference

### DIFF
--- a/mkdocs-project-dir/docs/stylesheets/tweaks.css
+++ b/mkdocs-project-dir/docs/stylesheets/tweaks.css
@@ -3,6 +3,8 @@
  * The contrast on the search entries was too low, apparently.
  * By default they're black with partial alpha; we set them
  * all to plain black, which should help.
+ *
+ * See below for switching for dark-mode.
  */
 
 .md-search-result__title {
@@ -22,26 +24,6 @@
     color: black;
 }
 
-/* BUT if we want to support dark mode and respect the user
- * preference for it, we need to pick white or black depending.
- */
-
-@media (prefers-color-scheme: dark) {
-    .md-search-result__title      { color: white; }
-    .md-search-result__link:hover { color: white; }
-    .md-search-result__meta       { color: white; }
-    .md-search-result__teaser     { color: white; }
-}
-
-@media (prefers-color-scheme: light) {
-    .md-search-result__title      { color: black; }
-    .md-search-result__link:hover { color: black; }
-    .md-search-result__meta       { color: black; }
-    .md-search-result__teaser     { color: black; }
-}
-
-
-
 /* Normally Pygments (the code highlighter)
  *  makes comments a pale grey, but that's not
  *  good either, especially since they're 
@@ -54,6 +36,30 @@
 .md-typeset .highlight .ch, 
 .md-typeset .highlight .cs {
     color: rebeccapurple;
+}
+
+/* If we want to support dark mode and respect the user
+ * preference for it, we need to pick white or black depending,
+ * and rebeccapurple is a little too dark for dark-mode.
+ *
+ * I think we only need the dark-mode switch, if the defaults
+ * will apply in light-mode.
+ */
+
+@media (prefers-color-scheme: dark) {
+    .md-search-result__title      { color: white; }
+    .md-search-result__link:hover { color: white; }
+    .md-search-result__meta       { color: white; }
+    .md-search-result__teaser     { color: white; }
+
+    .codehilite .c1, 
+    .codehilite .ch, 
+    .codehilite .cs, 
+    .md-typeset .highlight .c1, 
+    .md-typeset .highlight .ch, 
+    .md-typeset .highlight .cs {
+        color: mediumorchid;
+    }
 }
 
 /*

--- a/mkdocs-project-dir/docs/stylesheets/tweaks.css
+++ b/mkdocs-project-dir/docs/stylesheets/tweaks.css
@@ -13,7 +13,7 @@
     color: black;
 }
 
-// Number of search results box
+/* Number of search results box */
 .md-search-result__meta {
     color: black;
 }
@@ -21,6 +21,26 @@
 .md-search-result__teaser {
     color: black;
 }
+
+/* BUT if we want to support dark mode and respect the user
+ * preference for it, we need to pick white or black depending.
+ */
+
+@media (prefers-color-scheme: dark) {
+    .md-search-result__title      { color: white; }
+    .md-search-result__link:hover { color: white; }
+    .md-search-result__meta       { color: white; }
+    .md-search-result__teaser     { color: white; }
+}
+
+@media (prefers-color-scheme: light) {
+    .md-search-result__title      { color: black; }
+    .md-search-result__link:hover { color: black; }
+    .md-search-result__meta       { color: black; }
+    .md-search-result__teaser     { color: black; }
+}
+
+
 
 /* Normally Pygments (the code highlighter)
  *  makes comments a pale grey, but that's not

--- a/mkdocs-project-dir/mkdocs.yml
+++ b/mkdocs-project-dir/mkdocs.yml
@@ -25,6 +25,7 @@ theme:
   name: 'material'
   language: 'en'
   palette:
+    scheme: 'preference' # Respect user light-mode vs dark-mode preference
     primary: 'deep purple'
     accent: 'deep purple'
   font: false


### PR DESCRIPTION
As per the commit messages, this branch adds the mkdocs preference to switch palette based on the user's browser's preference for dark-mode or light-mode.

But because we tweak a few of the colours, those needed to detect it and change as well, so that's in the `tweaks.css` file.

If the user's browser doesn't support the media query about dark-mode at all, it should default to light-mode.