### PR TITLE
Update Example_Jobscripts.md

### DIFF
--- a/mkdocs-project-dir/docs/Example_Jobscripts.md
+++ b/mkdocs-project-dir/docs/Example_Jobscripts.md
@@ -91,7 +91,7 @@ cd $TMPDIR
 /bin/date > date.txt
 
 # Preferably, tar-up (archive) all output files onto the shared scratch area
-tar -zcvf $HOME/Scratch/files_from_job_$JOB_ID.tar.gz $TMPDIR
+tar -zcvf $HOME/Scratch/workspace/files_from_job_$JOB_ID.tar.gz $TMPDIR
 
 # Make sure you have given enough time for the copy to complete!
 ```


### PR DESCRIPTION
In the single-threaded example, TMPDIR is tarred into `$HOME/Scratch/....tar.gz` while the working directory is set to `$HOME/Scratch/workspace`, where all cout and cerr output is saved to. This change simply ensures all files from the example job end up in one folder: `$HOME/Scratch/workspace`.