### PR TITLE
Attempts to clarify the access of job scripts

### DIFF
--- a/mkdocs-project-dir/docs/Terms_and_Conditions.md
+++ b/mkdocs-project-dir/docs/Terms_and_Conditions.md
@@ -11,10 +11,11 @@ layout: docs
 2. All users will be required to renew their account once per year. Users will receive a reminder one month prior to suspension of their Myriad account sent to their Live@UCL e-mail address. Funding information will need to be provided upon application, and publication information upon renewal.
 3. Users are forbidden from performing production runs on the login nodes.
 4. The Research Computing Platform Services Team reserve the right to suspend or ban without prior warning any use of the system which impairs its operation.
-5. With the exception of in cases where there is imminent harm or risk to the service, the Research Computing Platform Services Team will not access your files without permission.
+5. With the exception of in cases where there is imminent harm or risk to the service, the Research Computing Platform Services Team will not access your files without permission.[^fn-jobscripts]
 6. Official service notifications are sent to the myriad-users (or the equivalent for other services) mailing list. Users are automatically subscribed to this list using their Live@UCL e-mail address and should read notices sent there.
 7. The Research Computing Platform Services Team reserve the right to suspend users' accounts, without notice, in the event of a user being the subject of any UCL disciplinary procedure, or where a user is found to be in breach of UCL’s Computing Regulations or best practice guidelines regarding password management, as provided by Information Services Division.
 8. Users are required to acknowledge their use of Myriad and associated research computing services in any publications describing research that has been conducted, in any part, on Myriad. The following words should be used:
     "The authors acknowledge the use of the UCL Myriad High Performance Computing Facility (Myriad@UCL), and associated support services, in the completion of this work". 
 9. All support requests should be sent by e-mail to rc-support@ucl.ac.uk.
 
+[^fn-jobscripts]: When you submit a job script, a copy is made, and that copy is public. This may appear as an exception to this term. Please do not include passwords or API keys in your job scripts.


### PR DESCRIPTION
The Terms of Service could probably use quite a few more alterations, updates, and clarifications, but this seemed important to note given that it may cause confusion when providing support.