### PR TITLE
Update SSH hostkey fingerprints

### DIFF
--- a/mkdocs-project-dir/docs/Supplementary/Hostkeys.md
+++ b/mkdocs-project-dir/docs/Supplementary/Hostkeys.md
@@ -39,16 +39,6 @@ RSA      MD5:06:17:f3:f2:0c:3e:0d:df:1d:04:fb:53:dc:77:60:56
 RSA      SHA256:DPcjbsUTBq3LwRggu4N+q2WQR0rkoM42jRdYXJtB86M
 ```
 
-## Thomas
-```
-ECDSA    MD5:6d:32:0f:81:8b:f6:c5:00:25:36:ed:3a:88:40:5a:17
-ECDSA    SHA256:r48udIRDfBEIJG+jiIJFs/56ZayaKUdusFd+JQ3jsO4
-ED25519  MD5:92:6d:97:46:eb:8d:0a:4b:8a:65:cb:0d:65:79:bb:7f
-ED25519  SHA256:waqBYWAb+g1lwUGWz8ku4M48McIBWGCdpMoU8l8j6tU
-RSA      MD5:f2:11:61:e6:01:b1:b2:ee:db:8b:ff:01:2d:85:b4:8b
-RSA      SHA256:AZ88UVU3BfZkSBOsMw5VKgbDi47o3dpEabPlIB9GtcM
-```
-
 ## Michael
 ```
 ECDSA    MD5:11:98:2e:c2:da:14:0c:d3:4e:a3:70:11:e1:59:72:7e

--- a/mkdocs-project-dir/docs/Supplementary/Hostkeys.md
+++ b/mkdocs-project-dir/docs/Supplementary/Hostkeys.md
@@ -3,42 +3,59 @@ title: Hostkeys
 layout: docs
 ---
 
-These are the current hostkey fingerprints for our clusters. The MD5 or SHA256 
+These are the current hostkey fingerprints for our clusters. The are different
+types of hostkeys (ECDSA, ED25519, RSA) and which one is used depends on your
+ssh client and its configuration. The MD5 or SHA256 
 at the front is letting you know what type of fingerprint it is - your ssh client 
 may not include that part in its output.
 
 ## Myriad
 ```
-ED25519 key fingerprint is MD5:92:6d:97:46:eb:8d:0a:4b:8a:65:cb:0d:65:79:bb:7f
-ECDSA key fingerprint is SHA256:7FTryal3mIhWr9CqM3EPPeXsfezNk8Mm8HPCCAGXiIA
-RSA key fingerprint is 29:a7:45:04:83:86:ec:95:fa:25:dc:7a:f4:93:78:c1
+ECDSA    MD5:db:06:ca:12:38:23:1f:12:ed:47:4f:51:0f:19:5d:23
+ECDSA    SHA256:7FTryal3mIhWr9CqM3EPPeXsfezNk8Mm8HPCCAGXiIA
+ED25519  MD5:92:6d:97:46:eb:8d:0a:4b:8a:65:cb:0d:65:79:bb:7f
+ED25519  SHA256:waqBYWAb+g1lwUGWz8ku4M48McIBWGCdpMoU8l8j6tU
+RSA      MD5:29:a7:45:04:83:86:ec:95:fa:25:dc:7a:f4:93:78:c1
+RSA      SHA256:8H13PdcJGJJbV/F3oBYXX7W1/8q/7m3gLBc8uZP3wio
 ```
 
 ## Kathleen
 ```
-ED25519 key fingerprint is MD5:92:6d:97:46:eb:8d:0a:4b:8a:65:cb:0d:65:79:bb:7f
-ECDSA key fingerprint is SHA256:rCKAb0yOWXK8+GClKy/pdbwrUbrGMvFkMciZLVcbaTA
-RSA key fingerprint is 5a:cf:95:a2:e4:05:8a:36:46:dc:65:0a:f2:8b:ab:e1
+ECDSA    MD5:6c:94:b2:01:c3:2f:58:5b:f3:03:02:cf:0f:ac:a0:d2
+ECDSA    SHA256:rCKAb0yOWXK8+GClKy/pdbwrUbrGMvFkMciZLVcbaTA
+ED25519  MD5:92:6d:97:46:eb:8d:0a:4b:8a:65:cb:0d:65:79:bb:7f
+ED25519  SHA256:waqBYWAb+g1lwUGWz8ku4M48McIBWGCdpMoU8l8j6tU
+RSA      MD5:5a:cf:95:a2:e4:05:8a:36:46:dc:65:0a:f2:8b:ab:e1
+RSA      SHA256:4SMOyhe/MVQ8aUOZyPfHjrIU5zHh7ZhmVd4zxzY+ukI
 ```
 
 ## Young
 ```
-ED25519 key fingerprint MD5 is 92:6d:97:46:eb:8d:0a:4b:8a:65:cb:0d:65:79:bb:7f
-ECDSA key fingerprint is SHA256:3zwMU9C8d9rgmYJ9qDElo15NnWyF2I4xy2X/VIAmFdo
-RSA key fingerprint is 06:17:f3:f2:0c:3e:0d:df:1d:04:fb:53:dc:77:60:56
+ECDSA    MD5:60:13:a6:4d:09:33:4d:67:1b:46:24:ee:44:66:71:17
+ECDSA    SHA256:3zwMU9C8d9rgmYJ9qDElo15NnWyF2I4xy2X/VIAmFdo
+ED25519  MD5:92:6d:97:46:eb:8d:0a:4b:8a:65:cb:0d:65:79:bb:7f
+ED25519  SHA256:waqBYWAb+g1lwUGWz8ku4M48McIBWGCdpMoU8l8j6tU
+RSA      MD5:06:17:f3:f2:0c:3e:0d:df:1d:04:fb:53:dc:77:60:56
+RSA      SHA256:DPcjbsUTBq3LwRggu4N+q2WQR0rkoM42jRdYXJtB86M
 ```
 
 ## Thomas
 ```
-ED25519 key fingerprint is MD5:92:6d:97:46:eb:8d:0a:4b:8a:65:cb:0d:65:79:bb:7f
-ECDSA key fingerprint is SHA256:r48udIRDfBEIJG+jiIJFs/56ZayaKUdusFd+JQ3jsO4
-RSA key fingerprint is SHA256:AZ88UVU3BfZkSBOsMw5VKgbDi47o3dpEabPlIB9GtcM
+ECDSA    MD5:6d:32:0f:81:8b:f6:c5:00:25:36:ed:3a:88:40:5a:17
+ECDSA    SHA256:r48udIRDfBEIJG+jiIJFs/56ZayaKUdusFd+JQ3jsO4
+ED25519  MD5:92:6d:97:46:eb:8d:0a:4b:8a:65:cb:0d:65:79:bb:7f
+ED25519  SHA256:waqBYWAb+g1lwUGWz8ku4M48McIBWGCdpMoU8l8j6tU
+RSA      MD5:f2:11:61:e6:01:b1:b2:ee:db:8b:ff:01:2d:85:b4:8b
+RSA      SHA256:AZ88UVU3BfZkSBOsMw5VKgbDi47o3dpEabPlIB9GtcM
 ```
 
 ## Michael
 ```
-ED25519 key fingerprint is MD5:b3:d9:60:a8:73:62:d5:91:ef:2b:ba:1e:d3:68:7c:ec
-ECDSA key fingerprint is SHA256:3PMLXp6ny0dECycvx4D7+t0sNgsSsLvSO5QUYmzkbhs
-RSA key fingerprint is 85:31:4b:cf:1a:ec:64:e4:b2:98:28:4a:46:b2:c1:90
+ECDSA    MD5:11:98:2e:c2:da:14:0c:d3:4e:a3:70:11:e1:59:72:7e
+ECDSA    SHA256:3PMLXp6ny0dECycvx4D7+t0sNgsSsLvSO5QUYmzkbhs
+ED25519  MD5:92:6d:97:46:eb:8d:0a:4b:8a:65:cb:0d:65:79:bb:7f
+ED25519  SHA256:waqBYWAb+g1lwUGWz8ku4M48McIBWGCdpMoU8l8j6tU
+RSA      MD5:85:31:4b:cf:1a:ec:64:e4:b2:98:28:4a:46:b2:c1:90
+RSA      SHA256:/qv4BAS9ga6C6iMwj8coEPQGg740CmazeDTFnXeGX+c
 ```
 


### PR DESCRIPTION
Different SSH clients and different versions may print either the MD5 or SHA256 fingerprint of the key, so document all of them.

Remove Thomas SSH hostkeys as it has been decommissioned.