### PR TITLE
Typo fix on Myriad landing page

### DIFF
--- a/mkdocs-project-dir/docs/Clusters/Myriad.md
+++ b/mkdocs-project-dir/docs/Clusters/Myriad.md
@@ -29,7 +29,7 @@ bulletpoints will show on screen - this is normal.
 If you are outside the UCL firewall you will need to follow the
 instructions for [Logging in from outside the UCL firewall](../howto.md#logging-in-from-outside-the-ucl-firewall).
 
-The login nodes allow you to manage your files, compile code and submit jobs. Very short (\<15mins) and non-resource-intensive software tests can be run on the login nodes, but anything more should be submitted as a job.
+The login nodes allow you to manage your files, compile code and submit jobs. Very short (< 15 mins) and non-resource-intensive software tests can be run on the login nodes, but anything more should be submitted as a job.
 
 ### Logging in to a specific node
 


### PR DESCRIPTION
The `<` doesn't need escaping, and if it is the slash shows up (see https://www.rc.ucl.ac.uk/docs/Clusters/Myriad/#logging-in), so remove it.