### PR TITLE
Change Mac OS X to macOS

### DIFF
--- a/mkdocs-project-dir/docs/Clusters/Michael.md
+++ b/mkdocs-project-dir/docs/Clusters/Michael.md
@@ -30,7 +30,7 @@ must not share your private key with anyone else. You can copy it onto
 multiple machines belonging to you so you can log in from all of them
 (or you can have a separate pair for each machine).
 
-### Creating an ssh key in Linux/Unix/Mac OS X
+### Creating an ssh key in Linux/Unix/macOS
 
 ```
 ssh-keygen -t rsa
@@ -487,4 +487,3 @@ their entire project, broken down by user. See
 Email <rc-support@ucl.ac.uk> with any support queries. It will be helpful
 to include Michael in the subject along with some descriptive text about
 the type of problem, and you should mention your username in the body.
-

--- a/mkdocs-project-dir/docs/Clusters/Young.md
+++ b/mkdocs-project-dir/docs/Clusters/Young.md
@@ -45,7 +45,7 @@ must not share your private key with anyone else. You can copy it onto
 multiple machines belonging to you so you can log in from all of them
 (or you can have a separate pair for each machine).
 
-### Creating an ssh key in Linux/Unix/Mac OS X
+### Creating an ssh key in Linux/Unix/macOS
 
 ```
 ssh-keygen -t rsa
@@ -686,4 +686,3 @@ please include:
 Molecular Modelling Hub, which is partially funded by EPSRC
 (EP/T022213/1, EP/W032260/1 and EP/P020194/1), for which access was obtained 
 via the UKCP consortium and funded by EPSRC grant ref EP/P022561/1"
-

--- a/mkdocs-project-dir/docs/Remote_Access.md
+++ b/mkdocs-project-dir/docs/Remote_Access.md
@@ -22,7 +22,7 @@ You can configure your ssh client to automatically connect via these jump boxes 
 
 ### Single-step logins using tunnelling
 
-#### Linux / Unix / Mac OS X
+#### Linux / Unix / macOS
 
 ##### On the command line
 ```
@@ -116,4 +116,3 @@ authorized_keys 100% 0 0.0KB/s 00:00
 ```
 
 and similarly if on `ejp-gateway01` do `scp -r ~/.ssh ejp-gateway02:`
-

--- a/mkdocs-project-dir/docs/Software_Guides/Matlab.md
+++ b/mkdocs-project-dir/docs/Software_Guides/Matlab.md
@@ -392,7 +392,7 @@ This directory needs to be in your Scratch directory as compute nodes need to be
 
 * Linux:
 The default local toolbox location is `/usr/local/MATLAB/R2021a/toolbox/local` for R2021a. Navigate to this directory and use `unzip -x archive_name`. 
-* Mac OS X:
+* macOS:
 The default local toolbox location is `/Applications/MATLAB_R2021a.app/toolbox/local` for R2021a. In order to view or change the contents of an application package, open `/Applications` in a Finder window. Then right-click the application and select "View Package Contents." Then navigate to the appropriate directory. Note: if you don't have access to `/Applications/MATLAB_R2021a.app/toolbox/local`, you can unzip the support files into `~/Documents/MATLAB/` instead. 
 * Windows:
 The default local toolbox location is `C:\Program Files\MATLAB\R2021a\toolbox\local` for R2021a. Extract the archive here. You can unzip the support files into `Documents\MATLAB\` instead.
@@ -532,5 +532,3 @@ tar zcvf $HOME/Scratch/Matlab_examples/files_from_job_${JOB_ID}.tgz $TMPDIR
 
 # Make sure you have given enough time for the copy to complete!
 ```
-
-

--- a/mkdocs-project-dir/docs/Supplementary/Troubleshooting.md
+++ b/mkdocs-project-dir/docs/Supplementary/Troubleshooting.md
@@ -86,7 +86,7 @@ what Myriad has it set to. You may be more likely to come across this
 with newer versions of macOS - if your client is different, have a
 look for an equivalent option.
 
-In Mac OS X Terminal, click Settings and under International untick the
+In macOS Terminal, click Settings and under International untick the
 box that says "Set locale environment variables on startup".
 
 Per session, you can try `LANG=C ssh userid@myriad.rc.ucl.ac.uk`
@@ -107,4 +107,3 @@ you see older job script examples mentioning a project ID, you can
 delete that section. Only projects with access to paid or specialised
 resources need to give a project code in order to use those resources.
 If you do not know yours, [contact rc-support](../Contact_Us.md).
-

--- a/mkdocs-project-dir/docs/howto.md
+++ b/mkdocs-project-dir/docs/howto.md
@@ -11,7 +11,7 @@ I have an account, now:
 
 Logging in is most straightforward if you are inside the UCL firewall. If you are logging in from home or other external networks then you first have to [get on to the UCL network](#logging-in-from-outside-the-ucl-firewall).
 
-### Linux / Unix / Mac OS X
+### Linux / Unix / macOS
 
 Use the terminal and type the below command to secure shell (ssh) into the machine you wish to access. Replace `<your_UCL_user_id>` with your central UCL username, and `<system_name>` with the name of the machine you want to log in to, eg. `myriad`, `kathleen`, `aristotle`. 
 
@@ -122,14 +122,14 @@ Typing `yes` will allow you to continue logging in.
 **WinSCP** will say `Server's host key does not match the one that WinSCP has in cache.` 
 and you will have the option to update the key.
 
-#### Mac OS X connection failures
+#### macOS connection failures
 
-If you are on Mac OS X and getting many ssh connection failures and broken pipe messages
+If you are on macOS and getting many ssh connection failures and broken pipe messages
 when trying to log in, try adding an ssh timeout to your ssh command:
 ```
 ssh -o ConnectTimeout=10 <your_UCL_user_id>@myriad.rc.ucl.ac.uk
 ```
-This has particularly been a problem with Mac OS X Big Sur when using the VPN.
+This has particularly been a problem with macOS Big Sur when using the VPN.
 
 ## How do I log out?
 
@@ -141,7 +141,7 @@ You can log out of the systems by typing `exit` and pressing enter.
 
 You can transfer data to and from our systems using any program capable of using the Secure Copy (SCP) protocol. This uses the same SSH system as you use to log in to a command line session, but then transfers data over it. This means that if you can use SSH to connect to a system, you can usually use SCP to transfer files to it. 
 
-### Copying files using Linux or Mac OS X
+### Copying files using Linux or macOS
 
 You can use the command-line utilities scp, sftp or rsync to copy your data about. You can also use a graphical client (Transmit, CyberDuck, FileZilla).
 
@@ -218,7 +218,7 @@ You can use the [UCL Virtual Private Network](https://www.ucl.ac.uk/isd/services
 
 ### Single-step logins using tunnelling
 
-#### Linux / Unix / Mac OS X
+#### Linux / Unix / macOS
 
 ##### On the command line
 
@@ -294,7 +294,7 @@ a graphical client.
 
 ##### SSH tunnel creation using a terminal
 
-You can do this in Linux, Mac OS X and the Windows Command Prompt on Windows 10 and later.
+You can do this in Linux, macOS and the Windows Command Prompt on Windows 10 and later.
 
 Set up a tunnel between a port on your local computer (this is using 3333 as it is unlikely to be
 in use, but you can pick different ones) to Myriad's port 22 (which is the standard port for ssh), 
@@ -658,9 +658,9 @@ ssh -X <your_UCL_user_id>@myriad.rc.ucl.ac.uk
 
 [A video walkthrough of running remote applications using X11, X-forwarding on compute nodes](https://www.youtube.com/watch?v=nVQlnuo3GSc).
 
-### X-forwarding on Mac OS X
+### X-forwarding on macOS
 
-You will need to install XQuartz to provide an X-Window System for Mac OS X. (Previously known as X11.app).
+You will need to install XQuartz to provide an X-Window System for macOS. (Previously known as X11.app).
 
 You can then follow the Linux instructions using Terminal.app.
 
@@ -697,4 +697,3 @@ Xming is a popular open source X server for Windows. These are instructions for 
 2. Open Xming - the Xming icon should appear on the task bar.
 3. Open PuTTY
 4. Set up PuTTY as shown in the Exceed section.
-


### PR DESCRIPTION
Mac OS X has been renamed macOS since 2016 (source: https://en.wikipedia.org/wiki/MacOS), so update mentions to macOS.