### PR TITLE
Adds htmlproofer plugin for mkdocs

### DIFF
--- a/mkdocs-project-dir/mkdocs.yml
+++ b/mkdocs-project-dir/mkdocs.yml
@@ -91,6 +91,12 @@ plugins:
   - search
   - awesome-pages
 # https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin
+  - htmlproofer:
+      enabled: !ENV [DOCS_ENABLE_HTMLPROOFER, True]
+      validate_external_urls: true
+      raise_error: !ENV [DOCS_FAIL_ON_BAD_LINK, False]
+      # ^-- ideally we would change the default here once all the initial problems have been fixed
+
 
 # Customization
 extra:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-awesome-pages-plugin
 pygments
 requests
 Mako
+mkdocs-htmlproofer-plugin


### PR DESCRIPTION
This is intended to catch bad anchors and broken external links.

It does also significantly increase build time, though, because of all the checking.

Because of that, two environment variables have been included in the `mkdocs.yml` file:

```
DOCS_ENABLE_HTMLPROOFER=True
DOCS_FAIL_ON_BAD_LINK=False
```

This lets you easily change whether these are enabled, for testing and local builds.

This idea taken from: <https://xahteiwi.eu/blog/2023/02/23/mkdocs/>